### PR TITLE
Fix Ore Dictionary Registration

### DIFF
--- a/src/main/java/com/nincodedo/nincraftythings/handler/ConfigurationHandler.java
+++ b/src/main/java/com/nincodedo/nincraftythings/handler/ConfigurationHandler.java
@@ -65,7 +65,7 @@ public class ConfigurationHandler {
 	private static void loadTweakConfigs(String category) {
 		Settings.Tweaks.enableEE3Tweaks = configuration.getBoolean("enableEE3Tweaks", category, true, "");
 		Settings.Tweaks.oreDictionaryAdditions = configuration.getStringList("oreDictionaryAdditions", category,
-				new String[] {}, "Add items to the ore dictionary formatted as modID|itemName|oreDictionaryName");
+				new String[] {}, "Add items to the ore dictionary formatted as modID|itemName|Metadata|oreDictionaryName");
 	}
 
 	private static void loadNincodiumArmorReductionConfigs(String category) {

--- a/src/main/java/com/nincodedo/nincraftythings/tweaks/OreDictionaryRegister.java
+++ b/src/main/java/com/nincodedo/nincraftythings/tweaks/OreDictionaryRegister.java
@@ -42,8 +42,6 @@ public class OreDictionaryRegister {
 
 	private static void registerOre(String itemName, int metadata, String oreDictEntry) {
 		OreDictionary.registerOre(oreDictEntry, GameRegistry.makeItemStack(itemName, metadata, 0, ""));
-		
-		System.out.println(itemName + ":" + (metadata == OreDictionary.WILDCARD_VALUE ? "*" : metadata) + " was registered to Ore Dictionary Entry " + oreDictEntry);
 	}
 
 	private static int getIntSafely(String input) {

--- a/src/main/java/com/nincodedo/nincraftythings/tweaks/OreDictionaryRegister.java
+++ b/src/main/java/com/nincodedo/nincraftythings/tweaks/OreDictionaryRegister.java
@@ -1,30 +1,56 @@
 package com.nincodedo.nincraftythings.tweaks;
 
-import java.util.Arrays;
 import java.util.List;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import com.google.common.collect.Lists;
 import com.nincodedo.nincraftythings.reference.Settings;
 
 import cpw.mods.fml.common.registry.GameRegistry;
-import net.minecraft.item.Item;
-import net.minecraftforge.oredict.OreDictionary;
 
 public class OreDictionaryRegister {
 
+	private static final String DELIMITER = "[|]";
+
 	public static void init() {
-		List<String> oreDic = Arrays.asList(Settings.Tweaks.oreDictionaryAdditions);
-		if (!oreDic.isEmpty()) {
-			String oreDicModId, oreDicItemName, oreDicName;
-			Item oreDicItem;
-			for (String entry : oreDic) {
-				oreDicModId = entry.split("|")[0];
-				oreDicItemName = entry.split("|")[1];
-				oreDicName = entry.split("|")[2];
-				oreDicItem = GameRegistry.findItem(oreDicModId, oreDicItemName);
-				if (oreDicItem != null) {
-					OreDictionary.registerOre(oreDicName, oreDicItem);
-				}
-			}
+		parseOreDictEntries();
+	}
+
+	private static void parseOreDictEntries() {
+		for (String entry : Lists.newArrayList(Settings.Tweaks.oreDictionaryAdditions)) {
+			parseOreDictEntry(entry);
+		}
+	}
+
+	private static void parseOreDictEntry(String entry) {
+		String[] entryData = entry.split(DELIMITER);
+
+		if (entryData.length < 3) {
+			// If we have less than 3 parts, back out now.
+			return;
+		} else if (entryData.length < 4) {
+			// If we have 3 parts, default to wildcard metadata
+			registerOre(entryData[0] + ":" + entryData[1], OreDictionary.WILDCARD_VALUE, entryData[2]);
+		} else {
+			// Otherwise, we have all 4 parts: mod id, item name, metadata, and oredict entry.
+			registerOre(entryData[0] + ":" + entryData[1], getIntSafely(entryData[2]), entryData[3]);
+		}
+	}
+
+	private static void registerOre(String itemName, int metadata, String oreDictEntry) {
+		OreDictionary.registerOre(oreDictEntry, GameRegistry.makeItemStack(itemName, metadata, 0, ""));
+		
+		System.out.println(itemName + ":" + (metadata == OreDictionary.WILDCARD_VALUE ? "*" : metadata) + " was registered to Ore Dictionary Entry " + oreDictEntry);
+	}
+
+	private static int getIntSafely(String input) {
+		try {
+			return Integer.parseInt(input);
+		} catch (NumberFormatException nfe) {
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
Should now allow metadata values if provided, otherwise will default to the wildcard, *.

Here's some screenshots:

Adding minecraft:wool:* to listAllWools
![First Image](http://i.imgur.com/AqBZQEZ.png)

Adding minecraft:wool:11 to woolBlue
![Second Image](http://i.imgur.com/i2xciGX.png)