### PR TITLE
Upgrade Ore Dictionary Tweaker

### DIFF
--- a/src/main/java/com/nincodedo/nincraftythings/tweaks/OreDictionaryRegister.java
+++ b/src/main/java/com/nincodedo/nincraftythings/tweaks/OreDictionaryRegister.java
@@ -1,15 +1,15 @@
 package com.nincodedo.nincraftythings.tweaks;
 
-import java.util.List;
-
-import net.minecraft.client.Minecraft;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.oredict.OreDictionary;
+import static net.minecraftforge.oredict.OreDictionary.getOres;
+import static net.minecraftforge.oredict.OreDictionary.registerOre;
+import static net.minecraftforge.oredict.OreDictionary.WILDCARD_VALUE;
 
 import com.google.common.collect.Lists;
 import com.nincodedo.nincraftythings.reference.Settings;
+import com.nincodedo.nincraftythings.utility.LogHelper;
 
 import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.item.ItemStack;
 
 public class OreDictionaryRegister {
 
@@ -28,27 +28,44 @@ public class OreDictionaryRegister {
 	private static void parseOreDictEntry(String entry) {
 		String[] entryData = entry.split(DELIMITER);
 
-		if (entryData.length < 3) {
-			// If we have less than 3 parts, back out now.
-			return;
-		} else if (entryData.length < 4) {
-			// If we have 3 parts, default to wildcard metadata
-			registerOre(entryData[0] + ":" + entryData[1], OreDictionary.WILDCARD_VALUE, entryData[2]);
-		} else {
-			// Otherwise, we have all 4 parts: mod id, item name, metadata, and oredict entry.
-			registerOre(entryData[0] + ":" + entryData[1], getIntSafely(entryData[2]), entryData[3]);
+		switch (entryData.length) {
+		case 2:
+			// OreDictFrom|oreDictTo
+			LogHelper.info("Registering all items under " + entryData[0] + " as " + entryData[1]);
+
+			for (final ItemStack ore : getOres(entryData[0])) {
+				registerOre(entryData[1], ore);
+			}
+			break;
+		case 3:
+			// ModId|ItemName|OreDict
+			LogHelper.info("Registering item " + entryData[0] + ":" + entryData[1] + " as " + entryData[2]);
+
+			registerEntry(entryData[0] + ":" + entryData[1], WILDCARD_VALUE, entryData[2]);
+			break;
+		case 4:
+			// ModId|ItemName|Metadata|OreDict
+			LogHelper.info("Registering item " + entryData[0] + ":" + entryData[1] + ":" + entryData[2] + " as "
+					+ entryData[3]);
+
+			registerEntry(entryData[0] + ":" + entryData[1], parseMetadata(entryData[2]), entryData[3]);
+			break;
+		default:
+			// lolidk wut u did.
+			LogHelper.warn("Unknown Config Value: " + String.join("|", entryData));
+			break;
 		}
 	}
 
-	private static void registerOre(String itemName, int metadata, String oreDictEntry) {
-		OreDictionary.registerOre(oreDictEntry, GameRegistry.makeItemStack(itemName, metadata, 0, ""));
+	private static void registerEntry(String itemName, int metadata, String oreDictEntry) {
+		registerOre(oreDictEntry, GameRegistry.makeItemStack(itemName, metadata, 0, ""));
 	}
 
-	private static int getIntSafely(String input) {
+	private static int parseMetadata(String input) {
 		try {
 			return Integer.parseInt(input);
 		} catch (NumberFormatException nfe) {
-			return 0;
+			return WILDCARD_VALUE;
 		}
 	}
 


### PR DESCRIPTION
Will now accept ore dictionary entries as input in the form of "oreDictIn|oreDictOut", and will register every item from that entry as the second.  This can be used to unify two entries.

Switched from an if/else structure to a swich/case one.